### PR TITLE
🐛Fix broken link to acceleraytor on homepage

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -239,7 +239,7 @@ function HomePageSection1() {
             <Button
               className="frosted-glass-teal"
               onClick={() => {
-                push('/acceleraytor')
+                push('https://raydium.io/acceleraytor/')
               }}
             >
               View Projects


### PR DESCRIPTION
Currently on the live website the homepage links to /acceleraytor that throws errors as I assume it's not ready yet

Perhaps until that page is ready, the link should go to v1 (https://raydium.io/acceleraytor/) or I suppose more directly (https://v1.raydium.io/acceleRaytor).  However I think the raydium.io/acceleraytor link could be updated dynamically without an additional UI code change

Current link leads to the following view:

![image](https://user-images.githubusercontent.com/101889896/166852319-b12e3108-c778-4d19-8838-83c87ed82e93.png)
