### PR TITLE
Increased priority fee cap to 5 sol

### DIFF
--- a/src/pageComponents/settings/SetTransactionPriority.tsx
+++ b/src/pageComponents/settings/SetTransactionPriority.tsx
@@ -95,7 +95,7 @@ export default function SetTransactionPriority() {
                 }
               }}
               pattern={/^\d*\.?\d*$/}
-              maximum={0.01}
+              maximum={5.00}
             />
             <div>SOL</div>
           </Row>


### PR DESCRIPTION
Recently there is a need for setting priority fees higher than 0.01 especially for things like creating pools and adding LP. This pull requests changes the priority fee cap to 5 sol which enables users to create pool even during high congestion.